### PR TITLE
PKF-293 spi disable at init

### DIFF
--- a/hw/mcu/nordic/nrf52xxx-compat/src/hal_spi.c
+++ b/hw/mcu/nordic/nrf52xxx-compat/src/hal_spi.c
@@ -649,6 +649,8 @@ hal_spi_init(int spi_num, void *cfg, uint8_t spi_type)
         goto err;
     }
 
+    hal_spi_disable(spi_num);
+
     if (spi_type == HAL_SPI_TYPE_MASTER) {
         rc = hal_spi_init_master(spi, (struct nrf52_hal_spi_cfg *)cfg,
                                  irq_handler);


### PR DESCRIPTION
This change disable SPI at init.
SPI may be initialized by bootloader and left in this state.
Call to configure SPI expects SPI do be disabled.

Same code was introduced in apache-mynewt-core for nrf52xxx mcu.
This adds same solution for nrf52xxx-compat.
See https://github.com/apache/mynewt-core/pull/1352 for reference