### PR TITLE
PKF-122 fix lis2dw12 selftest

### DIFF
--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
@@ -2030,13 +2030,23 @@ int lis2dw12_run_self_test(struct sensor_itf *itf, int *result)
     uint8_t prev_config[6];
     /* set config per datasheet, with positive self test mode enabled. */
     uint8_t st_config[] = {0x44, 0x04, 0x40, 0x00, 0x00, 0x10};
+    uint8_t fifo_ctrl;
 
     rc = lis2dw12_readlen(itf, LIS2DW12_REG_CTRL_REG1, prev_config, 6);
     if (rc) {
         return rc;
     }
+    rc = lis2dw12_read8(itf, LIS2DW12_REG_FIFO_CTRL, &fifo_ctrl);
+    if (rc) {
+        return rc;
+    }
     rc = lis2dw12_writelen(itf, LIS2DW12_REG_CTRL_REG2, &st_config[1], 5);
     rc = lis2dw12_writelen(itf, LIS2DW12_REG_CTRL_REG1, st_config, 1);
+    if (rc) {
+        return rc;
+    }
+
+    rc = lis2dw12_write8(itf, LIS2DW12_REG_FIFO_CTRL, 0);
     if (rc) {
         return rc;
     }
@@ -2099,6 +2109,11 @@ int lis2dw12_run_self_test(struct sensor_itf *itf, int *result)
         if (rc) {
             return rc;
         }
+
+    rc = lis2dw12_write8(itf, LIS2DW12_REG_FIFO_CTRL, fifo_ctrl);
+    if (rc) {
+        return rc;
+    }
 
     /* compare values to thresholds */
     *result = 0;


### PR DESCRIPTION
Function lis2dw12_run_self_test() worked correctly only
if FIFO mode was set to BYPASS.
FIFO mode is set to continues mode in K4 platform hence self test fails.

This change disables FIFO durgin selftest and restore original
mode after test is done.

**Test plan**
This requires lis2dw12 console to be enabled done in this PR https://github.com/PaxLabs/pax-common-code/pull/261

Once enabled command line should have lis2dw12 command.
To test selftest type
```
lis2dw12 test
```
Expected output
```
000727 SELF TEST: PASSED
```
Without this PR output would be
```
000793 SELF TEST: FAILED
```