### PR TITLE
PKF-396 lps33hw should try to read both pressure and temperature if i…

### DIFF
--- a/hw/drivers/sensors/lps33hw/src/lps33hw.c
+++ b/hw/drivers/sensors/lps33hw/src/lps33hw.c
@@ -1040,7 +1040,9 @@ lps33hw_sensor_read(struct sensor *sensor, sensor_type_t type,
 
             rc = data_func(sensor, data_arg, &spd, SENSOR_TYPE_PRESSURE);
         }
-    } else if (type & SENSOR_TYPE_TEMPERATURE) {
+    }
+
+    if (type & SENSOR_TYPE_TEMPERATURE) {
         struct sensor_temp_data std;
 
         rc = lps33hw_get_temperature(itf, &std.std_temp);


### PR DESCRIPTION
…nput type is of these types are set.

lps33hw read call has if() else() condition. Therefore if both temp and pressure mask are set, it calls only pressure read which is inside if() and does not call temp read inside else(). Making it if () + if () avoids this issue and calls both pressure, temp read().