### PR TITLE
PKF-462 Add a workaround to prevent energy leakage from SDO/SA0 pin.

### DIFF
--- a/hw/drivers/sensors/lis2dw12/syscfg.yml
+++ b/hw/drivers/sensors/lis2dw12/syscfg.yml
@@ -50,3 +50,6 @@ syscfg.defs:
     LIS2DW12_LOG_MODULE:
         description: 'Numeric module ID to use for LIS2DW12 log messages'
         value: 213
+    LIS2DW12_DISABLE_PULL_UP_SDO_SA0:
+        ddscription: 'A workaround to disable pull up on SDO/SA0. This is requested due to the pin is connected to ground.'
+        value: 1


### PR DESCRIPTION
Test method:
This change will only apply on a pin we are not used and it is connected to the ground. These can not verify with any test procedure. 
One test method will be read out LIS2DW12 register 0x17 and check if bit 6(0x40) is set. This register has calibration data in it. Each chip has its own value. You only need to check bit 6 is set.